### PR TITLE
Fix reflection instantiator for non public attributes

### DIFF
--- a/src/Instantiator/ReflectionInstantiator.php
+++ b/src/Instantiator/ReflectionInstantiator.php
@@ -13,7 +13,12 @@ class ReflectionInstantiator implements InstantiatorInterface
         $reflection = new \ReflectionClass($object);
 
         foreach ($data as $key => $value) {
-            $reflection->getProperty(Inflector::camelize($key))->setValue($object, $value);
+            $property = $reflection->getProperty(Inflector::camelize($key));
+            if (!$property->isPublic()) {
+                $property->setAccessible(true);
+            }
+
+            $property->setValue($object, $value);
         }
 
         return $object;

--- a/tests/InputHandlerTest.php
+++ b/tests/InputHandlerTest.php
@@ -8,15 +8,25 @@ use Prophecy\Argument;
 
 class TestUser
 {
-    public $name;
-    public $age;
-    public $date;
+    protected $name;
+    protected $age;
+    protected $date;
     public $isActive;
-    public $related;
+    protected $related;
+
+    public function getName()
+    {
+        return $this->name;
+    }
 
     public function setName($name)
     {
         $this->name = $name;
+    }
+
+    public function getAge()
+    {
+        return $this->age;
     }
 
     public function setAge($age)
@@ -27,6 +37,11 @@ class TestUser
     public function setIsActive(bool $isActive)
     {
         $this->isActive = $isActive;
+    }
+
+    public function getRelated() : TestUser
+    {
+        return $this->related;
     }
 
     public function setRelated(TestUser $related)

--- a/tests/Instantiator/PropertyInstantiatorTest.php
+++ b/tests/Instantiator/PropertyInstantiatorTest.php
@@ -10,10 +10,8 @@ class PropertyInstantiatorTest extends \PHPUnit_Framework_TestCase
     public function testIsCreatingInstances()
     {
         $instantiator = new PropertyInstantiator();
-        $instance = $instantiator->instantiate(TestUser::class, ['name' => 'foobar', 'age' => 20, 'is_active' => true]);
+        $instance = $instantiator->instantiate(TestUser::class, ['is_active' => true]);
         $this->assertInstanceOf(TestUser::class, $instance);
-        $this->assertEquals('foobar', $instance->name);
-        $this->assertEquals(20, $instance->age);
         $this->assertEquals(true, $instance->isActive);
     }
 }

--- a/tests/Instantiator/ReflectionInstantiatorTest.php
+++ b/tests/Instantiator/ReflectionInstantiatorTest.php
@@ -11,9 +11,10 @@ class ReflectionInstantiatorTest extends \PHPUnit_Framework_TestCase
     {
         $instantiator = new ReflectionInstantiator();
         $instance = $instantiator->instantiate(TestUser::class, ['name' => 'foobar', 'age' => 20, 'is_active' => true]);
+
         $this->assertInstanceOf(TestUser::class, $instance);
-        $this->assertEquals('foobar', $instance->name);
-        $this->assertEquals(20, $instance->age);
+        $this->assertEquals('foobar', $instance->getName());
+        $this->assertEquals(20, $instance->getAge());
         $this->assertEquals(true, $instance->isActive);
     }
 }

--- a/tests/Instantiator/SetInstantiatorTest.php
+++ b/tests/Instantiator/SetInstantiatorTest.php
@@ -12,8 +12,8 @@ class SetInstantiatorTest extends \PHPUnit_Framework_TestCase
         $instantiator = new SetInstantiator();
         $instance = $instantiator->instantiate(TestUser::class, ['name' => 'foobar', 'age' => 20, 'is_active' => true]);
         $this->assertInstanceOf(TestUser::class, $instance);
-        $this->assertEquals('foobar', $instance->name);
-        $this->assertEquals(20, $instance->age);
+        $this->assertEquals('foobar', $instance->getName());
+        $this->assertEquals(20, $instance->getAge());
         $this->assertEquals(true, $instance->isActive);
     }
 }


### PR DESCRIPTION
`ReflectionProperty::setValue` throws a `ReflectionException` if the property is inaccessible. [Docs](http://php.net/manual/en/reflectionproperty.setvalue.php#refsect1-reflectionproperty.setvalue-errors)

This PR check if a property is not accessible and use `ReflectionProperty::setAccessible` to make possible to set property value.