### PR TITLE
InputHandler composition improvements + Interface types

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,3 +261,61 @@ The library includes several instantiators by default:
 * ReflectionInstantiator
 
 By default, the `SetInstantiator` is used by Object and Collection nodes.
+
+InputHandlers
+-------------
+
+Linio Input supports portable, reusable InputHandlers via nesting. This is accomplished
+by including the `handler` to the options parameter when adding fields.
+
+Suppose your application deals with mailing addresses:
+
+```php
+<?php
+
+class OrderHandler extends InputHandler
+{
+    public function define()
+    {
+        $address = $this->add('shipping_address', Address::class);
+        $address->add('street', 'string');
+        $address->add('city', 'string');
+        $address->add('state', 'string');
+        $address->add('zip_code', 'integer');
+    }
+}
+```
+
+Rather than duplicating this everywhere you need to handle an address, you can extract the
+address into its own InputHandler and re-use it throughout your application.
+
+```php
+<?php
+
+class AddressHandler extends InputHandler
+{
+    public function define()
+    {
+        $address->add('street', 'string');
+        $address->add('city', 'string');
+        $address->add('state', 'string');
+        $address->add('zip_code', 'integer');
+    }
+}
+
+class OrderHandler extends InputHander
+{
+    public function define()
+    {
+        $this->add('shipping_address', Address::Class, ['handler' => new AddressHandler()]);
+    }
+}
+
+class RegistrationHandler extends InputHander
+{
+    public function define()
+    {
+        $this->add('home_address', Address::Class, ['handler' => new AddressHandler()]);
+    }
+}
+```

--- a/src/Node/BaseNode.php
+++ b/src/Node/BaseNode.php
@@ -6,6 +6,7 @@ namespace Linio\Component\Input\Node;
 use Linio\Component\Input\Constraint\ConstraintInterface;
 use Linio\Component\Input\Exception\InvalidConstraintException;
 use Linio\Component\Input\Exception\RequiredFieldException;
+use Linio\Component\Input\InputHandler;
 use Linio\Component\Input\Instantiator\InstantiatorInterface;
 use Linio\Component\Input\Transformer\TransformerInterface;
 use Linio\Component\Input\TypeHandler;
@@ -105,6 +106,15 @@ class BaseNode
     public function add(string $key, string $type, array $options = []): BaseNode
     {
         $child = $this->typeHandler->getType($type);
+
+        if (isset($options['handler'])) {
+            /** @var InputHandler $handler */
+            $handler = $options['handler'];
+            $handler->setRootType($type);
+            $handler->define();
+
+            $child = $handler->getRoot();
+        }
 
         if (isset($options['required'])) {
             $child->setRequired($options['required']);

--- a/src/TypeHandler.php
+++ b/src/TypeHandler.php
@@ -59,13 +59,6 @@ class TypeHandler
             return $type;
         }
 
-        if ($this->isInputHandler($name)) {
-            $handler = new $name($this);
-            $handler->define();
-
-            return $handler->getRoot();
-        }
-
         if ($this->isScalarCollectionType($name)) {
             $type = new ScalarCollectionNode();
             $type->setType($this->getCollectionType($name));
@@ -120,11 +113,6 @@ class TypeHandler
         }
 
         return true;
-    }
-
-    protected function isInputHandler(string $type): bool
-    {
-        return is_subclass_of($type, InputHandler::class);
     }
 
     protected function getCollectionType(string $type): string

--- a/src/TypeHandler.php
+++ b/src/TypeHandler.php
@@ -90,7 +90,7 @@ class TypeHandler
 
     protected function isClassType(string $type): bool
     {
-        return class_exists($type) && $type != 'datetime';
+        return (class_exists($type) || interface_exists($type)) && $type != 'datetime';
     }
 
     protected function isCollectionType(string $type): bool

--- a/tests/InputHandlerTest.php
+++ b/tests/InputHandlerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Linio\Component\Input;
 
 use Linio\Component\Input\Instantiator\InstantiatorInterface;
+use Linio\Component\Input\Instantiator\PropertyInstantiator;
 use Prophecy\Argument;
 
 class TestUser
@@ -92,7 +93,7 @@ class TestRecursiveInputHandler extends InputHandler
     {
         $this->add('title', 'string');
         $this->add('size', 'int');
-        $this->add('child', 'Linio\Component\Input\TestInputHandler');
+        $this->add('child', \stdClass::class, ['handler' => new TestInputHandler(), 'instantiator' => new PropertyInstantiator()]);
     }
 }
 
@@ -396,19 +397,20 @@ class InputHandlerTest extends \PHPUnit_Framework_TestCase
         // Basic fields
         $this->assertEquals('Barfoo', $inputHandler->getData('title'));
         $this->assertEquals(20, $inputHandler->getData('size'));
+        /** @var \stdClass $child */
         $child = $inputHandler->getData('child');
 
         // Scalar collection
-        $this->assertEquals([11, 22, 33], $child['dimensions']);
+        $this->assertEquals([11, 22, 33], $child->dimensions);
 
         // Transformer
-        $this->assertEquals(new \DateTime('2015-01-01 22:50'), $child['date']);
+        $this->assertEquals(new \DateTime('2015-01-01 22:50'), $child->date);
 
         // Mixed array
-        $this->assertEquals(['foo' => 'bar'], $child['metadata']);
+        $this->assertEquals(['foo' => 'bar'], $child->metadata);
 
         // Typed array
-        $this->assertEquals(['title' => 'Barfoo', 'size' => 15, 'date' => new \DateTime('2015-01-01 22:50')], $child['simple']);
+        $this->assertEquals(['title' => 'Barfoo', 'size' => 15, 'date' => new \DateTime('2015-01-01 22:50')], $child->simple);
 
         // Object and nested object
         $related = new TestUser();
@@ -418,7 +420,7 @@ class InputHandlerTest extends \PHPUnit_Framework_TestCase
         $author->setName('Barfoo');
         $author->setAge(28);
         $author->setRelated($related);
-        $this->assertEquals($author, $child['author']);
+        $this->assertEquals($author, $child->author);
 
         // Object collection
         $fanA = new TestUser();
@@ -433,6 +435,6 @@ class InputHandlerTest extends \PHPUnit_Framework_TestCase
         $fanC->setName('C');
         $fanC->setAge(38);
         $fanC->setBirthday(new \DateTime('2000-01-03'));
-        $this->assertEquals([$fanA, $fanB, $fanC], $child['fans']);
+        $this->assertEquals([$fanA, $fanB, $fanC], $child->fans);
     }
 }

--- a/tests/TypeHandlerTest.php
+++ b/tests/TypeHandlerTest.php
@@ -33,10 +33,21 @@ class TypeHandlerTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf(CollectionNode::class, $type);
     }
 
-    public function testIsCreatingObjects()
+    public function objectProvider()
+    {
+        return [
+            ['DateTime'],
+            [\DateTimeInterface::class],
+        ];
+    }
+
+    /**
+     * @dataProvider objectProvider
+     */
+    public function testIsCreatingObjects($className)
     {
         $typeHandler = new TypeHandler();
-        $type = $typeHandler->getType('DateTime');
+        $type = $typeHandler->getType($className);
         $this->assertInstanceOf(ObjectNode::class, $type);
     }
 

--- a/tests/TypeHandlerTest.php
+++ b/tests/TypeHandlerTest.php
@@ -40,13 +40,6 @@ class TypeHandlerTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf(ObjectNode::class, $type);
     }
 
-    public function testIsCreatingInputHandlers()
-    {
-        $typeHandler = new TypeHandler();
-        $type = $typeHandler->getType('Linio\Component\Input\InputHandler');
-        $this->assertInstanceOf(BaseNode::class, $type);
-    }
-
     public function testIsDetectingConflictWithCaseInsensitive()
     {
         $typeHandler = new TypeHandler();


### PR DESCRIPTION
This pull request improves support for recursive handler use and allows interfaces to be specified for types.

**Interface types**

Presently, one can set rules as follows, if `Foo` describes a class:

```php
$this->add('foo', Foo::class);
```

However, this isn't possible if `Foo` is an interface, as `class_exists(<some interface>)` returns false. This PR takes `interface_exists(...)` into consideration when deciding what type of node will be used for the input item. This is especially useful in cases where the final type of a bound item will implement a particular interface, but the specific concrete class that will be used will depend on the nature of the input.

Naturally, anyone using this convention _must_ also specify an `instantiator`, as all the built-in ones will fail when they try to `new` up an interface.

**InputHandler composition improvements**

Presently, recursive handlers work as follows:

```php
$this->add('foo', FooInputHandler::class);
```

This works to an extent, but has a few shortcomings.

1. It's misleading. The input item 'foo' will _not_ be of type `FooInputHandler` after it is bound. It will be a string, or an array, or some other object, etc..., but almost certainly never an `InputHandler`.
1. It supports only simple, dependency-free `InputHandler` instances.

Perhaps the `foo` input item is an array of data that will eventually be bound to an object of type `Foo`, and the process of validating and binding it involves some Transformers with dependencies on a datastore. Consider, instead:

```php
$this->add('foo', Foo::class, ['handler' => $this->fooInputHandler]);
```

This allows for the `InputHandler` that will be used to be injected into the parent `InputHandler`, complete with any required dependencies. It also encourages composition, as common complex input types can be factored out of larger input handlers and shared.