### PR TITLE
Fixed TypeErrors resulting from null content in some constraints

### DIFF
--- a/src/Constraint/GuidValue.php
+++ b/src/Constraint/GuidValue.php
@@ -12,7 +12,7 @@ class GuidValue extends Constraint
 
     public function validate($content): bool
     {
-        if (strlen($content) != 36) {
+        if ($content === null || strlen($content) != 36) {
             return false;
         }
 

--- a/src/Constraint/Range.php
+++ b/src/Constraint/Range.php
@@ -24,6 +24,10 @@ class Range extends Constraint
 
     public function validate($content): bool
     {
+        if ($content === null) {
+            return false;
+        }
+
         return $content >= $this->min && $content <= $this->max;
     }
 }

--- a/src/Constraint/StringSize.php
+++ b/src/Constraint/StringSize.php
@@ -24,6 +24,10 @@ class StringSize extends Constraint
 
     public function validate($content): bool
     {
+        if ($content === null) {
+            return false;
+        }
+
         $size = strlen($content);
 
         return $size >= $this->minSize && $size <= $this->maxSize;

--- a/src/Node/BaseNode.php
+++ b/src/Node/BaseNode.php
@@ -53,6 +53,11 @@ class BaseNode
      */
     protected $typeHandler;
 
+    /**
+     * @var bool
+     */
+    protected $allowNull = false;
+
     public function setConstraints(array $constraints)
     {
         $this->constraints = $constraints;
@@ -91,6 +96,11 @@ class BaseNode
     public function setDefault($default)
     {
         $this->default = $default;
+    }
+
+    public function setAllowNull(bool $allowNull)
+    {
+        $this->allowNull = $allowNull;
     }
 
     public function getDefault()
@@ -136,6 +146,10 @@ class BaseNode
             $child->setConstraints($options['constraints']);
         }
 
+        if (isset($options['allow_null'])) {
+            $child->setAllowNull($options['allow_null']);
+        }
+
         $this->children[$key] = $child;
 
         return $child;
@@ -168,8 +182,17 @@ class BaseNode
         return $this->required;
     }
 
+    public function allowNull(): bool
+    {
+        return $this->allowNull;
+    }
+
     public function getValue(string $field, $value)
     {
+        if ($this->allowNull() && $value === null) {
+            return $value;
+        }
+
         $this->checkConstraints($field, $value);
 
         if ($this->transformer) {

--- a/tests/Constraint/GuidValueTest.php
+++ b/tests/Constraint/GuidValueTest.php
@@ -14,6 +14,7 @@ class GuidValueTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($constraint->validate('0dca84b2-639d-406-bc87-7ab5ae3f5d4f'));
         $this->assertFalse($constraint->validate('0dca84b2-639d-4b06-c87-7ab5ae3f5d4f'));
         $this->assertFalse($constraint->validate('0dca84b2-639d-4b06-bc87-ab5ae3f5d4f'));
+        $this->assertFalse($constraint->validate(null));
     }
 
     public function testIsCheckingValidData()

--- a/tests/Constraint/RangeTest.php
+++ b/tests/Constraint/RangeTest.php
@@ -10,6 +10,7 @@ class RangeTest extends \PHPUnit_Framework_TestCase
         $constraint = new Range(50, 100);
         $this->assertFalse($constraint->validate(120));
         $this->assertFalse($constraint->validate(101));
+        $this->assertFalse($constraint->validate(null));
     }
 
     public function testIsCheckingValidData()

--- a/tests/Constraint/StringSizeTest.php
+++ b/tests/Constraint/StringSizeTest.php
@@ -15,6 +15,9 @@ class StringSizeTest extends \PHPUnit_Framework_TestCase
         $constraint2 = new StringSize(3, 5);
         $this->assertFalse($constraint2->validate('ab'));
         $this->assertFalse($constraint2->validate('abcdef'));
+
+        $this->assertFalse($constraint1->validate(null));
+        $this->assertFalse($constraint2->validate(null));
     }
 
     public function testIsCheckingValidData()

--- a/tests/Node/BaseNodeTest.php
+++ b/tests/Node/BaseNodeTest.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Linio\Component\Input\Node;
 
+use Linio\Component\Input\Constraint\NotNull;
 use Linio\Component\Input\TypeHandler;
 use Linio\Component\Input\Constraint\StringSize;
 use Linio\Component\Input\Transformer\DateTimeTransformer;
@@ -85,6 +86,17 @@ class BaseNodeTest extends \PHPUnit_Framework_TestCase
         $base->setTypeHandler($typeHandler->reveal());
         $child = $base->add('foobar', 'string', ['constraints' => [new StringSize(2, 5)]]);
         $child->getValue('foobar', 'foobar');
+    }
+
+    public function testAllowingNullValuesIfConstraintsWouldOtherwiseReject()
+    {
+        $typeHandler = $this->prophesize(TypeHandler::class);
+        $typeHandler->getType('string')->willReturn(new BaseNode());
+
+        $base = new BaseNode();
+        $base->setTypeHandler($typeHandler->reveal());
+        $child = $base->add('foobar', 'string', ['allow_null' => true, 'constraints' => [new NotNull()]]);
+        $child->getValue('foobar', null);
     }
 
     public function testIsGettingTransformedValue()


### PR DESCRIPTION
`strlen` blows up if you pass it a null with strict types on, so this will reject it outright. Also fixes allowing `null` to pass the `Range(0,1)` test.