### PR TITLE
Allow constructor-time error message customization

### DIFF
--- a/src/Constraint/DateRange.php
+++ b/src/Constraint/DateRange.php
@@ -15,11 +15,12 @@ class DateRange extends Constraint
      */
     protected $max;
 
-    public function __construct(string $min, string $max)
+    public function __construct(string $min, string $max, string $errorMessage = null)
     {
         $this->min = $min;
         $this->max = $max;
-        $this->errorMessage = sprintf('Date is not between "%s" and "%s"', $this->min, $this->max);
+
+        $this->setErrorMessage($errorMessage ?? sprintf('Date is not between "%s" and "%s"', $this->min, $this->max));
     }
 
     public function validate($content): bool

--- a/src/Constraint/Email.php
+++ b/src/Constraint/Email.php
@@ -5,9 +5,9 @@ namespace Linio\Component\Input\Constraint;
 
 class Email extends Constraint
 {
-    public function __construct()
+    public function __construct(string $errorMessage = null)
     {
-        $this->errorMessage = 'Invalid email format';
+        $this->setErrorMessage($errorMessage ?? 'Invalid email format');
     }
 
     public function validate($content): bool

--- a/src/Constraint/Enum.php
+++ b/src/Constraint/Enum.php
@@ -1,5 +1,5 @@
 <?php
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace Linio\Component\Input\Constraint;
 
@@ -10,10 +10,13 @@ class Enum extends Constraint
      */
     protected $enumValues = [];
 
-    public function __construct(array $enumValues)
+    public function __construct(array $enumValues, string $errorMessage = null)
     {
         $this->enumValues = $enumValues;
-        $this->errorMessage = 'Invalid option for enum. Allowed options are: ' . implode(', ', $this->enumValues);
+
+        $this->setErrorMessage(
+            $errorMessage ?? 'Invalid option for enum. Allowed options are: ' . implode(', ', $this->enumValues)
+        );
     }
 
     public function validate($content): bool

--- a/src/Constraint/GuidValue.php
+++ b/src/Constraint/GuidValue.php
@@ -5,9 +5,9 @@ namespace Linio\Component\Input\Constraint;
 
 class GuidValue extends Constraint
 {
-    public function __construct()
+    public function __construct(string $errorMessage = null)
     {
-        $this->errorMessage = 'Invalid GUID format';
+        $this->setErrorMessage($errorMessage ?? 'Invalid GUID format');
     }
 
     public function validate($content): bool

--- a/src/Constraint/NotNull.php
+++ b/src/Constraint/NotNull.php
@@ -5,9 +5,9 @@ namespace Linio\Component\Input\Constraint;
 
 class NotNull extends Constraint
 {
-    public function __construct()
+    public function __construct(string $errorMessage = null)
     {
-        $this->errorMessage = 'Unexpected empty content';
+        $this->setErrorMessage($errorMessage ?? 'Unexpected empty content');
     }
 
     public function validate($content): bool

--- a/src/Constraint/Pattern.php
+++ b/src/Constraint/Pattern.php
@@ -10,10 +10,11 @@ class Pattern extends Constraint
      */
     protected $pattern;
 
-    public function __construct(string $pattern)
+    public function __construct(string $pattern, string $errorMessage = null)
     {
         $this->pattern = $pattern;
-        $this->errorMessage = 'Required pattern does not match';
+
+        $this->setErrorMessage($errorMessage ?? 'Required pattern does not match');
     }
 
     public function validate($content): bool

--- a/src/Constraint/Range.php
+++ b/src/Constraint/Range.php
@@ -15,11 +15,12 @@ class Range extends Constraint
      */
     protected $max;
 
-    public function __construct(int $min, int $max = PHP_INT_MAX)
+    public function __construct(int $min, int $max = PHP_INT_MAX, string $errorMessage = null)
     {
         $this->min = $min;
         $this->max = $max;
-        $this->errorMessage = sprintf('Value is not between %d and %d', $this->min, $this->max);
+
+        $this->setErrorMessage($errorMessage ?? sprintf('Value is not between %d and %d', $this->min, $this->max));
     }
 
     public function validate($content): bool

--- a/src/Constraint/StringSize.php
+++ b/src/Constraint/StringSize.php
@@ -1,5 +1,5 @@
 <?php
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace Linio\Component\Input\Constraint;
 
@@ -15,11 +15,14 @@ class StringSize extends Constraint
      */
     protected $maxSize;
 
-    public function __construct(int $minSize, int $maxSize = PHP_INT_MAX)
+    public function __construct(int $minSize, int $maxSize = PHP_INT_MAX, string $errorMessage = null)
     {
         $this->minSize = $minSize;
         $this->maxSize = $maxSize;
-        $this->errorMessage = sprintf('Content out of min/max limit sizes [%s, %s]', $this->minSize, $this->maxSize);
+
+        $this->setErrorMessage(
+            $errorMessage ?? sprintf('Content out of min/max limit sizes [%s, %s]', $this->minSize, $this->maxSize)
+        );
     }
 
     public function validate($content): bool

--- a/src/Constraint/Type.php
+++ b/src/Constraint/Type.php
@@ -10,10 +10,11 @@ class Type extends Constraint
      */
     protected $type;
 
-    public function __construct(string $type)
+    public function __construct(string $type, string $errorMessage = null)
     {
         $this->type = $type;
-        $this->errorMessage = 'Value does not match type: ' . $this->type;
+
+        $this->setErrorMessage($errorMessage ?? 'Value does not match type: ' . $this->type);
     }
 
     public function validate($content): bool

--- a/src/Constraint/Url.php
+++ b/src/Constraint/Url.php
@@ -5,9 +5,9 @@ namespace Linio\Component\Input\Constraint;
 
 class Url extends Constraint
 {
-    public function __construct()
+    public function __construct(string $errorMessage = null)
     {
-        $this->errorMessage = 'Invalid URL format';
+        $this->setErrorMessage($errorMessage ?? 'Invalid URL format');
     }
 
     public function validate($content): bool

--- a/tests/Constraint/DateRangeTest.php
+++ b/tests/Constraint/DateRangeTest.php
@@ -25,4 +25,10 @@ class DateRangeTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($constraint->validate('yesterday'));
         $this->assertEquals('[field] Date is not between "today" and "+3 days"', $constraint->getErrorMessage('field'));
     }
+
+    public function testErrorMessageIsCustomizable()
+    {
+        $constraint = new DateRange('today', '+3days', 'CUSTOM!');
+        $this->assertSame('[field] CUSTOM!', $constraint->getErrorMessage('field'));
+    }
 }

--- a/tests/Constraint/EmailTest.php
+++ b/tests/Constraint/EmailTest.php
@@ -27,4 +27,10 @@ class EmailTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($constraint->validate('foobar.com'));
         $this->assertEquals('[field] Invalid email format', $constraint->getErrorMessage('field'));
     }
+
+    public function testErrorMessageIsCustomizable()
+    {
+        $constraint = new Email('CUSTOM!');
+        $this->assertSame('[field] CUSTOM!', $constraint->getErrorMessage('field'));
+    }
 }

--- a/tests/Constraint/EnumTest.php
+++ b/tests/Constraint/EnumTest.php
@@ -25,4 +25,10 @@ class EnumTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($constraint->validate('test'), 'The "test" value is not part of the Enum');
         $this->assertEquals('[field] Invalid option for enum. Allowed options are: foo, bar', $constraint->getErrorMessage('field'));
     }
+
+    public function testErrorMessageIsCustomizable()
+    {
+        $constraint = new Enum(['foo', 'bar'], 'CUSTOM!');
+        $this->assertSame('[field] CUSTOM!', $constraint->getErrorMessage('field'));
+    }
 }

--- a/tests/Constraint/GuidValueTest.php
+++ b/tests/Constraint/GuidValueTest.php
@@ -30,4 +30,10 @@ class GuidValueTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($constraint->validate('0dga84b2-639d-4b06-bc87-7ab5ae3f5d4f'));
         $this->assertEquals('[field] Invalid GUID format', $constraint->getErrorMessage('field'));
     }
+
+    public function testErrorMessageIsCustomizable()
+    {
+        $constraint = new GuidValue('CUSTOM!');
+        $this->assertSame('[field] CUSTOM!', $constraint->getErrorMessage('field'));
+    }
 }

--- a/tests/Constraint/NotNullTest.php
+++ b/tests/Constraint/NotNullTest.php
@@ -27,4 +27,10 @@ class NotNullTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($constraint->validate(null));
         $this->assertEquals('[field] Unexpected empty content', $constraint->getErrorMessage('field'));
     }
+
+    public function testErrorMessageIsCustomizable()
+    {
+        $constraint = new NotNull('CUSTOM!');
+        $this->assertSame('[field] CUSTOM!', $constraint->getErrorMessage('field'));
+    }
 }

--- a/tests/Constraint/PatternTest.php
+++ b/tests/Constraint/PatternTest.php
@@ -27,4 +27,10 @@ class PatternTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($constraint->validate(null));
         $this->assertEquals('[field] Required pattern does not match', $constraint->getErrorMessage('field'));
     }
+
+    public function testErrorMessageIsCustomizable()
+    {
+        $constraint = new Pattern('/^\d{4}\-\d{2}-\d{2}$/', 'CUSTOM!');
+        $this->assertSame('[field] CUSTOM!', $constraint->getErrorMessage('field'));
+    }
 }

--- a/tests/Constraint/RangeTest.php
+++ b/tests/Constraint/RangeTest.php
@@ -26,4 +26,10 @@ class RangeTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($constraint->validate(14));
         $this->assertEquals('[field] Value is not between 50 and 100', $constraint->getErrorMessage('field'));
     }
+
+    public function testErrorMessageIsCustomizable()
+    {
+        $constraint = new Range(50, 100, 'CUSTOM!');
+        $this->assertSame('[field] CUSTOM!', $constraint->getErrorMessage('field'));
+    }
 }

--- a/tests/Constraint/StringSizeTest.php
+++ b/tests/Constraint/StringSizeTest.php
@@ -42,4 +42,10 @@ class StringSizeTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($constraint->validate('ab'));
         $this->assertEquals('[field] Content out of min/max limit sizes [3, 5]', $constraint->getErrorMessage('field'));
     }
+
+    public function testErrorMessageIsCustomizable()
+    {
+        $constraint = new StringSize(1, 2, 'CUSTOM!');
+        $this->assertSame('[field] CUSTOM!', $constraint->getErrorMessage('field'));
+    }
 }

--- a/tests/Constraint/TypeTest.php
+++ b/tests/Constraint/TypeTest.php
@@ -1,5 +1,5 @@
 <?php
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace Linio\Component\Input\Constraint;
 
@@ -24,5 +24,11 @@ class TypeTest extends \PHPUnit_Framework_TestCase
         $constraint = new Type('int');
         $this->assertFalse($constraint->validate('test'));
         $this->assertEquals('[field] Value does not match type: int', $constraint->getErrorMessage('field'));
+    }
+
+    public function testErrorMessageIsCustomizable()
+    {
+        $constraint = new Type('int', 'CUSTOM!');
+        $this->assertSame('[field] CUSTOM!', $constraint->getErrorMessage('field'));
     }
 }

--- a/tests/Constraint/UrlTest.php
+++ b/tests/Constraint/UrlTest.php
@@ -1,5 +1,5 @@
 <?php
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace Linio\Component\Input\Constraint;
 
@@ -28,5 +28,11 @@ class UrlTest extends \PHPUnit_Framework_TestCase
         $constraint = new Url();
         $this->assertFalse($constraint->validate('foobarcom'));
         $this->assertEquals('[field] Invalid URL format', $constraint->getErrorMessage('field'));
+    }
+
+    public function testErrorMessageIsCustomizable()
+    {
+        $constraint = new Url('CUSTOM!');
+        $this->assertSame('[field] CUSTOM!', $constraint->getErrorMessage('field'));
     }
 }


### PR DESCRIPTION
This PR adds the ability to customize a constraint error message at construction time.

```php
$node->add('field1', 'string', ['constraints' => [
    new StringSize(1, 50, 'This is a custom error message!'),
    new Pattern('.....', 'This is another custom error message!')]]
);
```

vs

```php
$stringSize = new StringSize(1, 50);
$stringSize->setErrorMessage('This is a custom error message!');

$pattern = new Pattern('.....');
$pattern->setErrorMessage('This is another custom error message!');

$node->add('field1', 'string', ['constraints' => [$stringSize, $pattern]);
```

As this is achieved via a new optional argument added to the end of the `__construct(...)` signature, it does not break BC.