### PR TITLE
Add a property existence checker to go with getData

### DIFF
--- a/src/InputHandler.php
+++ b/src/InputHandler.php
@@ -81,6 +81,11 @@ abstract class InputHandler
         return $this->output;
     }
 
+    public function hasData($index)
+    {
+        return isset($this->output[$index]);
+    }
+
     public function isValid(): bool
     {
         return empty($this->errors);

--- a/tests/InputHandlerTest.php
+++ b/tests/InputHandlerTest.php
@@ -144,6 +144,8 @@ class InputHandlerTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($inputHandler->isValid());
 
         // Basic fields
+        $this->assertTrue($inputHandler->hasData('title'));
+        $this->assertFalse($inputHandler->hasData('...'));
         $this->assertEquals('Foobar', $inputHandler->getData('title'));
         $this->assertEquals(35, $inputHandler->getData('size'));
 


### PR DESCRIPTION
Simple checker for property existence. Child classes could check `$this->output` directly because it's `protected`, but this spares the effort of having to implement it every time.