### PR TITLE
Fix TypeError on non-string GuidValue

### DIFF
--- a/src/Constraint/GuidValue.php
+++ b/src/Constraint/GuidValue.php
@@ -12,7 +12,7 @@ class GuidValue extends Constraint
 
     public function validate($content): bool
     {
-        if ($content === null || strlen($content) != 36) {
+        if (!is_string($content) || strlen($content) != 36) {
             return false;
         }
 

--- a/tests/Constraint/GuidValueTest.php
+++ b/tests/Constraint/GuidValueTest.php
@@ -15,6 +15,8 @@ class GuidValueTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($constraint->validate('0dca84b2-639d-4b06-c87-7ab5ae3f5d4f'));
         $this->assertFalse($constraint->validate('0dca84b2-639d-4b06-bc87-ab5ae3f5d4f'));
         $this->assertFalse($constraint->validate(null));
+        $this->assertFalse($constraint->validate([]));
+        $this->assertFalse($constraint->validate(new \stdClass()));
     }
 
     public function testIsCheckingValidData()


### PR DESCRIPTION
strlen only accepts strings with strict_types enabled. While it
technically also accepts integers in loosely typed mode, an integer can
never be a valid Guid, so the constraint validation would still give the
correct result.