### PR TITLE
Fix unpack error for arrays with string keys.

### DIFF
--- a/src/Instantiator/ConstructInstantiator.php
+++ b/src/Instantiator/ConstructInstantiator.php
@@ -7,6 +7,6 @@ class ConstructInstantiator implements InstantiatorInterface
 {
     public function instantiate(string $class, array $data)
     {
-        return new $class(...$data);
+        return new $class(...array_values($data));
     }
 }

--- a/tests/Instantiator/ConstructInstantiatorTest.php
+++ b/tests/Instantiator/ConstructInstantiatorTest.php
@@ -10,6 +10,14 @@ class ConstructInstantiatorTest extends \PHPUnit_Framework_TestCase
     public function testIsCreatingInstances()
     {
         $instantiator = new ConstructInstantiator();
+        $instance = $instantiator->instantiate('ErrorException', ['foobar']);
+        $this->assertInstanceOf('ErrorException', $instance);
+        $this->assertEquals(new \ErrorException('foobar'), $instance);
+    }
+
+    public function testIsHandlingArraysWithStringKeys()
+    {
+        $instantiator = new ConstructInstantiator();
         $instance = $instantiator->instantiate(Enum::class, ['foo' => [1, 2], 'bar' => 'message']);
         $this->assertEquals(new Enum([1, 2], 'message'), $instance);
     }

--- a/tests/Instantiator/ConstructInstantiatorTest.php
+++ b/tests/Instantiator/ConstructInstantiatorTest.php
@@ -3,13 +3,14 @@ declare(strict_types=1);
 
 namespace Linio\Component\Input\Instantiator;
 
+use Linio\Component\Input\Constraint\Enum;
+
 class ConstructInstantiatorTest extends \PHPUnit_Framework_TestCase
 {
     public function testIsCreatingInstances()
     {
         $instantiator = new ConstructInstantiator();
-        $instance = $instantiator->instantiate('ErrorException', ['foobar']);
-        $this->assertInstanceOf('ErrorException', $instance);
-        $this->assertEquals(new \ErrorException('foobar'), $instance);
+        $instance = $instantiator->instantiate(Enum::class, ['foo' => [1, 2], 'bar' => 'message']);
+        $this->assertEquals(new Enum([1, 2], 'message'), $instance);
     }
 }


### PR DESCRIPTION
Without this fix it's not possible to use the ConstructInstantiator when using ObjectNode because `\Linio\Component\Input\InputHandler::bind` is passing an array with string keys to `\Linio\Component\Input\Node\ObjectNode::getValue` and then unpacking that array directly into the class constructor `return new $class(...$data);`.

`1) Linio\Component\Input\Instantiator\ConstructInstantiatorTest::testIsCreatingInstances
Error: Cannot unpack array with string keys

/Users/caio/Company/Linio/Project/input/src/Instantiator/ConstructInstantiator.php:10
/Users/caio/Company/Linio/Project/input/tests/Instantiator/ConstructInstantiatorTest.php:13
/Users/caio/Company/Linio/Project/input/vendor/phpunit/phpunit/phpunit:52`