### PR TITLE
Added stictType to Enum constraint to support type validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ composer.lock
 phpunit.xml
 cache.properties
 .php_cs.cache
+.idea/

--- a/src/Constraint/Enum.php
+++ b/src/Constraint/Enum.php
@@ -10,9 +10,15 @@ class Enum extends Constraint
      */
     protected $enumValues = [];
 
-    public function __construct(array $enumValues, string $errorMessage = null)
+    /**
+     * @var bool
+     */
+    protected $strictType;
+
+    public function __construct(array $enumValues, string $errorMessage = null, $strictType = false)
     {
         $this->enumValues = $enumValues;
+        $this->strictType = $strictType;
 
         $this->setErrorMessage(
             $errorMessage ?? 'Invalid option for enum. Allowed options are: ' . implode(', ', $this->enumValues)
@@ -21,6 +27,6 @@ class Enum extends Constraint
 
     public function validate($content): bool
     {
-        return in_array($content, $this->enumValues);
+        return in_array($content, $this->enumValues, $this->strictType);
     }
 }

--- a/tests/Constraint/EnumTest.php
+++ b/tests/Constraint/EnumTest.php
@@ -12,11 +12,28 @@ class EnumTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($constraint->validate('blah'), 'The "blah" value is not part of the Enum');
     }
 
+    public function testIsCheckingInvalidDataWithStrictType()
+    {
+        $constraint = new Enum(['01', '02', '03', '4', 5], null, true);
+        $this->assertFalse($constraint->validate(2), 'The "2" value is not part of the Enum');
+        $this->assertFalse($constraint->validate(4), 'The "01" value is not part of the Enum');
+        $this->assertFalse($constraint->validate('5'), 'The "5" value is not part of the Enum');
+    }
+
     public function testIsCheckingValidData()
     {
-        $constraint = new Enum(['foo', 'bar']);
+        $constraint = new Enum(['foo', 'bar', '08', 7]);
         $this->assertTrue($constraint->validate('foo'), 'The "foo" value should be part of the Enum');
         $this->assertTrue($constraint->validate('bar'), 'The "bar" value should be part of the Enum');
+        $this->assertTrue($constraint->validate(8), 'The "8" value should be part of the Enum');
+        $this->assertTrue($constraint->validate('07'), 'The "07" value should be part of the Enum');
+    }
+
+    public function testIsCheckingValidDataWithStrictType()
+    {
+        $constraint = new Enum(['01', '02', '03', '4'], null, true);
+        $this->assertTrue($constraint->validate('02'), 'The "02" value should be part of the Enum');
+        $this->assertTrue($constraint->validate('4'), 'The "4" value should be part of the Enum');
     }
 
     public function testIsGettingErrorMessage()


### PR DESCRIPTION
In LinioPay we needed a way to validate that the value '8' is not the same as '08' which was in an Enum constraint. The following changes were made to expand the Enum() constraint:

* Added `$strictType` to the construct with default set to `false` to maintain current behavior.
* Passed in the property `strictType` to the third param of `in_array()` in the validate function.
* Expanded the tests to take into account the new `strictType` construct var.