### PR TITLE
Ability of default objects

### DIFF
--- a/src/InputHandler.php
+++ b/src/InputHandler.php
@@ -56,8 +56,9 @@ abstract class InputHandler
         $this->root = $this->typeHandler->getType($type);
     }
 
-    public function bind(array $input)
+    public function bind(array $input, array $defaults = [])
     {
+        $this->root->setDefaults($defaults);
         $this->define();
 
         try {

--- a/src/Node/BaseNode.php
+++ b/src/Node/BaseNode.php
@@ -64,6 +64,11 @@ class BaseNode
      */
     protected $allowNull = false;
 
+    /**
+     * @var array
+     */
+    protected $defaults = [];
+
     public function setConstraints(array $constraints)
     {
         $this->constraints = $constraints;
@@ -134,6 +139,30 @@ class BaseNode
         return (bool) $this->default;
     }
 
+    /**
+     * Gets the value of defaults.
+     *
+     * @return array
+     */
+    public function getDefaults(): array
+    {
+        return $this->defaults;
+    }
+
+    /**
+     * Sets the value of defaults.
+     *
+     * @param array $defaults the defaults
+     *
+     * @return self
+     */
+    public function setDefaults(array $defaults): self
+    {
+        $this->defaults = $defaults;
+
+        return $this;
+    }
+
     public function add(string $key, string $type, array $options = []): BaseNode
     {
         $child = $this->typeHandler->getType($type);
@@ -169,6 +198,10 @@ class BaseNode
 
         if (isset($options['allow_null'])) {
             $child->setAllowNull($options['allow_null']);
+        }
+
+        if (array_key_exists($key, $this->defaults)) {
+            $child->setDefault($this->defaults[$key]);
         }
 
         $this->children[$key] = $child;

--- a/src/Node/ObjectNode.php
+++ b/src/Node/ObjectNode.php
@@ -4,11 +4,23 @@ declare(strict_types=1);
 
 namespace Linio\Component\Input\Node;
 
+use Doctrine\Common\Inflector\Inflector;
+
 class ObjectNode extends BaseNode
 {
     public function getValue(string $field, $value)
     {
         $this->checkConstraints($field, $value);
+
+        if ($this->hasDefault()) {
+            $object = $this->default;
+            foreach ($value as $key => $val) {
+                $method = 'set' . Inflector::classify($key);
+                $object->$method($val);
+            }
+
+            return $object;
+        }
 
         return $this->instantiator->instantiate($this->type, $value);
     }

--- a/tests/InputHandlerTest.php
+++ b/tests/InputHandlerTest.php
@@ -98,8 +98,73 @@ class TestRecursiveInputHandler extends InputHandler
     }
 }
 
+class DummyUser
+{
+    protected $id;
+
+    protected $name;
+
+    /**
+     * Gets the value of id.
+     *
+     * @return mixed
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function setId($id): self
+    {
+        $this->id = $id;
+
+        return $this;
+    }
+
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    public function setName($name): self
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+}
+
+class TestDefaultsInputHandler extends InputHandler
+{
+    public function define()
+    {
+        $user = $this->add('user', DummyUser::class);
+        $user->add('name', 'string');
+    }
+}
+
 class InputHandlerTest extends TestCase
 {
+    public function testIsHandlingDefaults()
+    {
+        $input = [
+            'user' => [
+                'name' => 'Foo',
+            ],
+        ];
+
+        $user = new DummyUser();
+        $user->setId(1);
+        $user->setName('Bar');
+
+        $inputHandler = new TestDefaultsInputHandler();
+        $inputHandler->bind($input, ['user' => $user]);
+
+        // Basic fields
+        $this->assertEquals('Foo', $inputHandler->getData('user')->getName());
+        $this->assertEquals(1, $inputHandler->getData('user')->getId());
+    }
+
     public function testIsHandlingBasicInput()
     {
         $input = [


### PR DESCRIPTION
This pull request covers a new feature that allows you have a default object reference.

I will give the example that I added on tests:

```php
class DummyUser
{
    protected $id;
    protected $name;

    /**
     * Getters and Setters
     */
}

class TestDefaultsInputHandler extends InputHandler
{
    public function define()
    {
        $user = $this->add('user', DummyUser::class);
        $user->add('name', 'string');
    }
}

$input = [
    'user' => [
        'name' => 'Foo'
    ]
];

$user = new DummyUser();
$user->setId(1);
$user->setName('Bar');

$inputHandler = new TestDefaultsInputHandler();
$inputHandler->bind($input, ['user' => $user]); // Here you pass your reference object

$user->getId(); // outputs "1"
$user->getName(); // outputs "Foo"
```