### PR TITLE
Fixed datetime input validation

### DIFF
--- a/src/Constraint/DateTime.php
+++ b/src/Constraint/DateTime.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Linio\Component\Input\Constraint;
+
+class DateTime extends Constraint
+{
+    public function validate($content): bool
+    {
+        if (!is_string($content)) {
+            return false;
+        }
+
+        $date = date_parse($content);
+        return $date['error_count'] ? false : true;
+    }
+}

--- a/src/Constraint/DateTime.php
+++ b/src/Constraint/DateTime.php
@@ -13,6 +13,7 @@ class DateTime extends Constraint
         }
 
         $date = date_parse($content);
+
         return $date['error_count'] ? false : true;
     }
 }

--- a/src/Constraint/Type.php
+++ b/src/Constraint/Type.php
@@ -20,6 +20,12 @@ class Type extends Constraint
 
     public function validate($content): bool
     {
+        if ($this->type === 'datetime') {
+            $date = date_parse($content);
+
+            return $date['error_count'] ? false : true;
+        }
+
         return call_user_func('is_' . $this->type, $content);
     }
 }

--- a/src/Constraint/Type.php
+++ b/src/Constraint/Type.php
@@ -20,13 +20,6 @@ class Type extends Constraint
 
     public function validate($content): bool
     {
-        switch ($this->type) {
-            case 'datetime':
-                $date = date_parse($content);
-
-                return $date['error_count'] ? false : true;
-            default:
-                return call_user_func('is_' . $this->type, $content);
-        }
+        return call_user_func('is_' . $this->type, $content);
     }
 }

--- a/src/Constraint/Type.php
+++ b/src/Constraint/Type.php
@@ -20,12 +20,13 @@ class Type extends Constraint
 
     public function validate($content): bool
     {
-        if ($this->type === 'datetime') {
-            $date = date_parse($content);
+        switch ($this->type) {
+            case 'datetime':
+                $date = date_parse($content);
 
-            return $date['error_count'] ? false : true;
+                return $date['error_count'] ? false : true;
+            default:
+                return call_user_func('is_' . $this->type, $content);
         }
-
-        return call_user_func('is_' . $this->type, $content);
     }
 }

--- a/src/Node/DateTimeNode.php
+++ b/src/Node/DateTimeNode.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace Linio\Component\Input\Node;
 
-use Linio\Component\Input\Constraint\Type;
+use Linio\Component\Input\Constraint\DateTime;
 use Linio\Component\Input\Transformer\DateTimeTransformer;
 
 class DateTimeNode extends BaseNode
 {
     public function __construct()
     {
-        $this->addConstraint(new Type('datetime'));
+        $this->addConstraint(new DateTime());
         $this->transformer = new DateTimeTransformer();
     }
 }

--- a/src/Node/DateTimeNode.php
+++ b/src/Node/DateTimeNode.php
@@ -4,13 +4,14 @@ declare(strict_types=1);
 
 namespace Linio\Component\Input\Node;
 
+use Linio\Component\Input\Constraint\Type;
 use Linio\Component\Input\Transformer\DateTimeTransformer;
 
 class DateTimeNode extends BaseNode
 {
     public function __construct()
     {
-        $this->type = 'datetime';
+        $this->addConstraint(new Type('datetime'));
         $this->transformer = new DateTimeTransformer();
     }
 }

--- a/tests/InputHandlerTest.php
+++ b/tests/InputHandlerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Linio\Component\Input;
 
+use Linio\Component\Input\Constraint\Range;
 use Linio\Component\Input\Instantiator\InstantiatorInterface;
 use Linio\Component\Input\Instantiator\PropertyInstantiator;
 use PHPUnit\Framework\TestCase;
@@ -68,6 +69,11 @@ class TestInputHandler extends InputHandler
         $this->add('date', 'datetime');
         $this->add('metadata', 'array');
 
+        $this->add('price', 'int', [
+            'required' => true,
+            'constraints' => [new Range(0)],
+        ]);
+
         $simple = $this->add('simple', 'array');
         $simple->add('title', 'string', ['default' => 'Barfoo']);
         $simple->add('size', 'int', ['required' => false, 'default' => 15]);
@@ -103,6 +109,7 @@ class InputHandlerTest extends TestCase
     public function testIsHandlingBasicInput()
     {
         $input = [
+            'price' => 'igor',
             'title' => 'Foobar',
             'size' => 35,
             'dimensions' => [11, 22, 33],
@@ -239,6 +246,7 @@ class InputHandlerTest extends TestCase
     public function testIsHandlingTypeJuggling()
     {
         $input = [
+            'price' => 'igor',
             'title' => '',
             'size' => 0,
             'dimensions' => [0, 0, 0],
@@ -351,6 +359,7 @@ class InputHandlerTest extends TestCase
             'title' => 'Barfoo',
             'size' => 20,
             'child' => [
+                'price' => 'igor',
                 'title' => 'Foobar',
                 'size' => 35,
                 'dimensions' => [11, 22, 33],

--- a/tests/InputHandlerTest.php
+++ b/tests/InputHandlerTest.php
@@ -445,10 +445,32 @@ class InputHandlerTest extends TestCase
     public function testOverride()
     {
         $input = [
-            'price' => 'igor'
+            'price' => 'igor',
         ];
 
         $inputHandler = new TestConstraintOverrideType();
+        $inputHandler->bind($input);
+        $this->assertFalse($inputHandler->isValid());
+    }
+
+    public function testDatetimeEmptyDatetime()
+    {
+        $input = [
+            'date' => '',
+        ];
+
+        $inputHandler = new TestDatetimeNotValidatingDate();
+        $inputHandler->bind($input);
+        $this->assertFalse($inputHandler->isValid());
+    }
+
+    public function testDatetimeInvalidDatetime()
+    {
+        $input = [
+            'date' => 'Invalid%20date',
+        ];
+
+        $inputHandler = new TestDatetimeNotValidatingDate();
         $inputHandler->bind($input);
         $this->assertFalse($inputHandler->isValid());
     }
@@ -460,10 +482,17 @@ class TestConstraintOverrideType extends InputHandler
     {
         $this->add('price', 'int', [
             'required' => true,
-            'constraints' => [new Range(0)]
+            'constraints' => [new Range(0)],
         ]);
     }
 }
 
-
-
+class TestDatetimeNotValidatingDate extends InputHandler
+{
+    public function define()
+    {
+        $this->add('date', 'datetime', [
+            'required' => true,
+        ]);
+    }
+}

--- a/tests/InputHandlerTest.php
+++ b/tests/InputHandlerTest.php
@@ -453,21 +453,32 @@ class InputHandlerTest extends TestCase
         $this->assertFalse($inputHandler->isValid());
     }
 
-    public function testDatetimeEmptyDatetime()
+    public function invalidDateProvider() : \Generator
     {
-        $input = [
-            'date' => '',
-        ];
+        yield [''];
 
-        $inputHandler = new TestDatetimeNotValidatingDate();
-        $inputHandler->bind($input);
-        $this->assertFalse($inputHandler->isValid());
+        yield ['Invalid%20date'];
+
+        yield [123];
+
+        yield [false];
+
+        yield [true];
+
+        yield [[]];
+
+        yield [null];
     }
 
-    public function testDatetimeInvalidDatetime()
+    /**
+     * @dataProvider invalidDateProvider
+     *
+     * @param mixed $datetime
+     */
+    public function testDatetimeInvalidDatetimeInput($datetime)
     {
         $input = [
-            'date' => 'Invalid%20date',
+            'date' => $datetime,
         ];
 
         $inputHandler = new TestDatetimeNotValidatingDate();

--- a/tests/InputHandlerTest.php
+++ b/tests/InputHandlerTest.php
@@ -69,11 +69,6 @@ class TestInputHandler extends InputHandler
         $this->add('date', 'datetime');
         $this->add('metadata', 'array');
 
-        $this->add('price', 'int', [
-            'required' => true,
-            'constraints' => [new Range(0)],
-        ]);
-
         $simple = $this->add('simple', 'array');
         $simple->add('title', 'string', ['default' => 'Barfoo']);
         $simple->add('size', 'int', ['required' => false, 'default' => 15]);
@@ -109,7 +104,6 @@ class InputHandlerTest extends TestCase
     public function testIsHandlingBasicInput()
     {
         $input = [
-            'price' => 'igor',
             'title' => 'Foobar',
             'size' => 35,
             'dimensions' => [11, 22, 33],
@@ -246,7 +240,6 @@ class InputHandlerTest extends TestCase
     public function testIsHandlingTypeJuggling()
     {
         $input = [
-            'price' => 'igor',
             'title' => '',
             'size' => 0,
             'dimensions' => [0, 0, 0],
@@ -359,7 +352,6 @@ class InputHandlerTest extends TestCase
             'title' => 'Barfoo',
             'size' => 20,
             'child' => [
-                'price' => 'igor',
                 'title' => 'Foobar',
                 'size' => 35,
                 'dimensions' => [11, 22, 33],
@@ -449,4 +441,29 @@ class InputHandlerTest extends TestCase
         $fanC->setBirthday(new \DateTime('2000-01-03'));
         $this->assertEquals([$fanA, $fanB, $fanC], $child->fans);
     }
+
+    public function testOverride()
+    {
+        $input = [
+            'price' => 'igor'
+        ];
+
+        $inputHandler = new TestConstraintOverrideType();
+        $inputHandler->bind($input);
+        $this->assertFalse($inputHandler->isValid());
+    }
 }
+
+class TestConstraintOverrideType extends InputHandler
+{
+    public function define()
+    {
+        $this->add('price', 'int', [
+            'required' => true,
+            'constraints' => [new Range(0)]
+        ]);
+    }
+}
+
+
+

--- a/tests/InputHandlerTest.php
+++ b/tests/InputHandlerTest.php
@@ -453,7 +453,7 @@ class InputHandlerTest extends TestCase
         $this->assertFalse($inputHandler->isValid());
     }
 
-    public function invalidDateProvider() : \Generator
+    public function invalidDateProvider(): \Generator
     {
         yield [''];
 


### PR DESCRIPTION
Discovered this little wrong behavior while validation `datetime` type. Adding just the type to DateTimeNode wasn't validating datetime, so what was made is adding to base the constraint, but as the validation of datetime is different added a statement for it. Added tests that can corroborate.