### PR TITLE
Allow to set null as default value

### DIFF
--- a/src/Constraint/GuidValue.php
+++ b/src/Constraint/GuidValue.php
@@ -15,7 +15,7 @@ class GuidValue extends Constraint
 
     public function validate($content): bool
     {
-        if (!is_string($content) || strlen($content) != 36) {
+        if (!is_string($content) || 36 != strlen($content)) {
             return false;
         }
 

--- a/src/Constraint/NotNull.php
+++ b/src/Constraint/NotNull.php
@@ -17,6 +17,6 @@ class NotNull extends Constraint
             $content = trim($content);
         }
 
-        return $content !== null && $content !== '';
+        return null !== $content && '' !== $content;
     }
 }

--- a/src/Constraint/Range.php
+++ b/src/Constraint/Range.php
@@ -30,7 +30,7 @@ class Range extends Constraint
             return false;
         }
 
-        if ($content === null) {
+        if (null === $content) {
             return false;
         }
 

--- a/src/Constraint/StringSize.php
+++ b/src/Constraint/StringSize.php
@@ -32,7 +32,7 @@ class StringSize extends Constraint
             return false;
         }
 
-        if ($content === null) {
+        if (null === $content) {
             return false;
         }
 

--- a/src/Node/BaseNode.php
+++ b/src/Node/BaseNode.php
@@ -140,7 +140,7 @@ class BaseNode
         return $this->hasDefault;
     }
 
-    public function add(string $key, string $type, array $options = []): BaseNode
+    public function add(string $key, string $type, array $options = []): self
     {
         $child = $this->typeHandler->getType($type);
 
@@ -216,7 +216,7 @@ class BaseNode
 
     public function getValue(string $field, $value)
     {
-        if ($this->allowNull() && $value === null) {
+        if ($this->allowNull() && null === $value) {
             return $value;
         }
 

--- a/src/Node/BaseNode.php
+++ b/src/Node/BaseNode.php
@@ -50,6 +50,11 @@ class BaseNode
     protected $default;
 
     /**
+     * @var bool
+     */
+    protected $hasDefault = false;
+
+    /**
      * @var BaseNode[]
      */
     protected $children = [];
@@ -117,6 +122,7 @@ class BaseNode
     public function setDefault($default)
     {
         $this->default = $default;
+        $this->hasDefault = true;
     }
 
     public function setAllowNull(bool $allowNull)
@@ -131,7 +137,7 @@ class BaseNode
 
     public function hasDefault(): bool
     {
-        return (bool) $this->default;
+        return $this->hasDefault;
     }
 
     public function add(string $key, string $type, array $options = []): BaseNode
@@ -151,7 +157,7 @@ class BaseNode
             $child->setRequired($options['required']);
         }
 
-        if (isset($options['default'])) {
+        if (array_key_exists('default', $options)) {
             $child->setDefault($options['default']);
         }
 

--- a/src/Node/IntNode.php
+++ b/src/Node/IntNode.php
@@ -15,6 +15,6 @@ class IntNode extends BaseNode
 
     public function hasDefault(): bool
     {
-        return is_int($this->default);
+        return is_int($this->default) || (parent::hasDefault() && $this->allowNull() && null === $this->default);
     }
 }

--- a/src/Transformer/DateTimeTransformer.php
+++ b/src/Transformer/DateTimeTransformer.php
@@ -8,7 +8,7 @@ class DateTimeTransformer implements TransformerInterface
 {
     public function transform($value)
     {
-        if ($value === null) {
+        if (null === $value) {
             return;
         }
 

--- a/src/TypeHandler.php
+++ b/src/TypeHandler.php
@@ -95,7 +95,7 @@ class TypeHandler
 
     protected function isClassType(string $type): bool
     {
-        return (class_exists($type) || interface_exists($type)) && $type != 'datetime';
+        return (class_exists($type) || interface_exists($type)) && 'datetime' != $type;
     }
 
     protected function isCollectionType(string $type): bool
@@ -124,7 +124,7 @@ class TypeHandler
     {
         $pos = strrpos($type, '[]');
 
-        if ($pos === false) {
+        if (false === $pos) {
             return $type;
         }
 

--- a/tests/InputHandlerTest.php
+++ b/tests/InputHandlerTest.php
@@ -38,12 +38,12 @@ class TestUser
         $this->age = $age;
     }
 
-    public function getRelated(): TestUser
+    public function getRelated(): self
     {
         return $this->related;
     }
 
-    public function setRelated(TestUser $related)
+    public function setRelated(self $related)
     {
         $this->related = $related;
     }
@@ -285,7 +285,7 @@ class InputHandlerTest extends TestCase
         $this->assertEquals('', $inputHandler->getData('title'));
         $this->assertEquals(0, $inputHandler->getData('size'));
         $this->assertEquals([0, 0, 0], $inputHandler->getData('dimensions'));
-        $this->assertEquals(false, $inputHandler->getData('author')->isActive);
+        $this->assertFalse($inputHandler->getData('author')->isActive);
     }
 
     public function testIsHandlingInputValidationWithInstantiator()

--- a/tests/Instantiator/ReflectionInstantiatorTest.php
+++ b/tests/Instantiator/ReflectionInstantiatorTest.php
@@ -17,6 +17,6 @@ class ReflectionInstantiatorTest extends TestCase
         $this->assertInstanceOf(TestUser::class, $instance);
         $this->assertEquals('foobar', $instance->getName());
         $this->assertEquals(20, $instance->getAge());
-        $this->assertEquals(true, $instance->isActive);
+        $this->assertTrue($instance->isActive);
     }
 }

--- a/tests/Instantiator/SetInstantiatorTest.php
+++ b/tests/Instantiator/SetInstantiatorTest.php
@@ -16,6 +16,6 @@ class SetInstantiatorTest extends TestCase
         $this->assertInstanceOf(TestUser::class, $instance);
         $this->assertEquals('foobar', $instance->getName());
         $this->assertEquals(20, $instance->getAge());
-        $this->assertEquals(true, $instance->isActive);
+        $this->assertTrue($instance->isActive);
     }
 }

--- a/tests/Node/BaseNodeTest.php
+++ b/tests/Node/BaseNodeTest.php
@@ -129,4 +129,16 @@ class BaseNodeTest extends TestCase
         $child = $base->add('foobar', 'string', ['transformer' => new DateTimeTransformer()]);
         $this->assertEquals(new \DateTime('2014-01-01 00:00:00'), $child->getValue('foobar', '2014-01-01 00:00:00'));
     }
+
+    public function testIsAllowingToSetDefaultNull()
+    {
+        $typeHandler = $this->prophesize(TypeHandler::class);
+        $typeHandler->getType('string')->willReturn(new BaseNode());
+
+        $base = new BaseNode();
+        $base->setTypeHandler($typeHandler->reveal());
+        $child = $base->add('foobar', 'string', ['default' => null]);
+        $this->assertTrue($child->hasDefault());
+        $this->assertNull($child->getDefault());
+    }
 }

--- a/tests/Node/IntNodeTest.php
+++ b/tests/Node/IntNodeTest.php
@@ -15,4 +15,22 @@ class IntNodeTest extends TestCase
 
         $this->assertTrue($node->hasDefault());
     }
+
+    public function testIsReturningNullForDefaultValueNullWhenNullIsAllowed()
+    {
+        $node = new IntNode();
+        $node->setAllowNull(true);
+        $node->setDefault(null);
+
+        $this->assertTrue($node->hasDefault());
+    }
+
+    public function testIsNotReturningNullForDefaultValueNullWhenNullIsNotAllowed()
+    {
+        $node = new IntNode();
+        $node->setAllowNull(false);
+        $node->setDefault(null);
+
+        $this->assertFalse($node->hasDefault());
+    }
 }


### PR DESCRIPTION
When using `ConstructInstantiator` with nullable arguments for an optional input the only way to have the value injected is setting the handler with this definition:

```php
class SomeClassHandler extends InputHandler
{
    public function define()
        $this->add('someField', 'int', [
            'allow_null' => true,
            'required' => false,
            'default' => null,
        ]);
    }
}
```

But the null default value is not set on the constructor data because `hasDefault` method on `BaseNode` tries to check for default values using `(bool) $this->default`. This, of course, is a problem even for empty strings or integers with value 0 set as default.