### PR TITLE
Error when walking null values

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: php
 
 php:
-  - 7.0
-  
+  - 7.1
+  - 7.2
+
 cache:
   directories:
     - vendor

--- a/src/Instantiator/PropertyInstantiator.php
+++ b/src/Instantiator/PropertyInstantiator.php
@@ -8,8 +8,12 @@ use Doctrine\Common\Inflector\Inflector;
 
 class PropertyInstantiator implements InstantiatorInterface
 {
-    public function instantiate(string $class, array $data)
+    public function instantiate(string $class, ?array $data)
     {
+        if (is_null($data)) {
+            return null;
+        }
+        
         $object = new $class();
 
         foreach ($data as $key => $value) {

--- a/src/Instantiator/PropertyInstantiator.php
+++ b/src/Instantiator/PropertyInstantiator.php
@@ -10,10 +10,10 @@ class PropertyInstantiator implements InstantiatorInterface
 {
     public function instantiate(string $class, ?array $data)
     {
-        if (is_null($data)) {
+        if ($data === null) {
             return null;
         }
-        
+
         $object = new $class();
 
         foreach ($data as $key => $value) {

--- a/src/Node/BaseNode.php
+++ b/src/Node/BaseNode.php
@@ -229,11 +229,11 @@ class BaseNode
             return $input;
         }
 
-        $result = [];
-
         if (!$this->hasChildren()) {
             return $input;
         }
+
+        $result = [];
 
         foreach ($this->getChildren() as $field => $config) {
             if (!array_key_exists($field, $input)) {

--- a/src/Node/BaseNode.php
+++ b/src/Node/BaseNode.php
@@ -225,6 +225,10 @@ class BaseNode
 
     public function walk($input)
     {
+        if (!is_array($input)) {
+            return $input;
+        }
+
         $result = [];
 
         if (!$this->hasChildren()) {

--- a/tests/InputHandlerTest.php
+++ b/tests/InputHandlerTest.php
@@ -116,7 +116,7 @@ class TestNullableRecursiveInputHandler extends InputHandler
         $this->add('data', \stdClass::class, [
             'handler' => new TestNullableInputHandler(),
             'instantiator' => new PropertyInstantiator(),
-            'allow_null' => true
+            'allow_null' => true,
         ]);
     }
 }
@@ -512,8 +512,8 @@ class InputHandlerTest extends TestCase
             'type' => 'buyers',
             'data' => [
                 'name' => 'John Doe',
-                'address' => null
-            ]
+                'address' => null,
+            ],
         ];
 
         $inputHandler = new TestNullableRecursiveInputHandler();
@@ -527,7 +527,7 @@ class InputHandlerTest extends TestCase
 
         $input = [
             'type' => 'buyers',
-            'data' => null
+            'data' => null,
         ];
 
         $inputHandler = new TestNullableRecursiveInputHandler();


### PR DESCRIPTION
Hello, we're having a very specific issue using this library for validation of input inside LinioPay services.

```
{
		"headers": {
			"Content-type": ["application/json; charset=UTF-8"]
		},
		"body": "{\"type\":\"server_error\",\"message\":\"Internal Server Error\",\"errors\":[],\"reference_id\":\"aoiscjizxcn19nczocnq\"}",
		"parsed_body": {
			"type": "server_error",
			"message": "Internal Server Error",
			"errors": [],
			"reference_id": "aoiscjizxcn19nczocnq"
		},
		"exception_class": "TypeError",
		"exception_message": "array_key_exists() expects parameter 2 to be array, null given",
		"exception_code": 0,
		"exception_file": "/path/to/project/vendor/linio/input/src/Node/BaseNode.php",
		"exception_line": 235,
		"tags": []
	}
```

So, to tackle this issue I added a validation to check whether the input is an array or not. If it is not an array, I just return the input itself.

Let me know what you think. It's a minor issue for us, but we need to get the fix released as soon as possible.

Thanks!