### PR TITLE
add set handler method and cascade request

### DIFF
--- a/src/InputHandler.php
+++ b/src/InputHandler.php
@@ -36,9 +36,9 @@ abstract class InputHandler
         $this->root->setTypeHandler($this->typeHandler);
     }
 
-    public function add(string $key, string $type, array $options = []): BaseNode
+    public function add(string $key, string $type, array $options = [], InputHandler $handler = null): BaseNode
     {
-        return $this->root->add($key, $type, $options);
+        return $this->root->add($key, $type, $options, $handler);
     }
 
     public function remove(string $key): void

--- a/src/Node/BaseNode.php
+++ b/src/Node/BaseNode.php
@@ -61,44 +61,60 @@ class BaseNode
      */
     protected $allowNull = false;
 
-    public function setConstraints(array $constraints): void
+    public function setConstraints(array $constraints): self
     {
         $this->constraints = $constraints;
+
+        return $this;
     }
 
-    public function addConstraint(ConstraintInterface $constraint): void
+    public function addConstraint(ConstraintInterface $constraint): self
     {
         $this->constraints[] = $constraint;
+
+        return $this;
     }
 
-    public function addConstraints(array $constraints): void
+    public function addConstraints(array $constraints): self
     {
         $this->constraints = array_merge($this->constraints, $constraints);
+
+        return $this;
     }
 
-    public function setTransformer(TransformerInterface $transformer): void
+    public function setTransformer(TransformerInterface $transformer): self
     {
         $this->transformer = $transformer;
+
+        return $this;
     }
 
-    public function setInstantiator(InstantiatorInterface $instantiator): void
+    public function setInstantiator(InstantiatorInterface $instantiator): self
     {
         $this->instantiator = $instantiator;
+
+        return $this;
     }
 
-    public function setTypeHandler(TypeHandler $typeHandler): void
+    public function setTypeHandler(TypeHandler $typeHandler): self
     {
         $this->typeHandler = $typeHandler;
+
+        return $this;
     }
 
-    public function setType(string $type): void
+    public function setType(string $type): self
     {
         $this->type = $type;
+
+        return $this;
     }
 
-    public function setTypeAlias(string $typeAlias): void
+    public function setTypeAlias(string $typeAlias): self
     {
         $this->typeAlias = $typeAlias;
+
+        return $this;
     }
 
     public function getTypeAlias(): string
@@ -106,19 +122,25 @@ class BaseNode
         return $this->typeAlias;
     }
 
-    public function setRequired(bool $required): void
+    public function setRequired(bool $required): self
     {
         $this->required = $required;
+
+        return $this;
     }
 
-    public function setDefault($default): void
+    public function setDefault($default): self
     {
         $this->default = $default;
+
+        return $this;
     }
 
-    public function setAllowNull(bool $allowNull): void
+    public function setAllowNull(bool $allowNull): self
     {
         $this->allowNull = $allowNull;
+
+        return $this;
     }
 
     public function getDefault()

--- a/src/Node/BaseNode.php
+++ b/src/Node/BaseNode.php
@@ -153,17 +153,16 @@ class BaseNode
         return (bool) $this->default;
     }
 
-    public function add(string $key, string $type, array $options = []): BaseNode
+    public function add(string $key, string $type, array $options = [], InputHandler $handler = null): BaseNode
     {
         $child = $this->typeHandler->getType($type);
 
-        if (isset($options['handler'])) {
-            /** @var InputHandler $handler */
-            $handler = $options['handler'];
-            $handler->setRootType($type);
-            $handler->define();
+        if (isset($handler)) {
+            $child = $child->setHandler($handler, $type);
+        }
 
-            $child = $handler->getRoot();
+        if (isset($options['handler']) && !isset($handler)) {
+            $child = $child->setHandler($options['handler'], $type);
         }
 
         if (isset($options['required'])) {
@@ -280,5 +279,13 @@ class BaseNode
                 throw new InvalidConstraintException($constraint->getErrorMessage($field));
             }
         }
+    }
+
+    private function setHandler(InputHandler $handler, string $type): self
+    {
+        $handler->setRootType($type);
+        $handler->define();
+
+        return $handler->getRoot();
     }
 }

--- a/src/Node/BaseNode.php
+++ b/src/Node/BaseNode.php
@@ -44,9 +44,6 @@ class BaseNode
      */
     protected $required = true;
 
-    /**
-     * @var mixed
-     */
     protected $default;
 
     /**

--- a/tests/InputHandlerTest.php
+++ b/tests/InputHandlerTest.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace Linio\Component\Input;
 
+use Linio\Component\Input\Constraint\Email;
+use Linio\Component\Input\Constraint\Enum;
 use Linio\Component\Input\Constraint\Range;
+use Linio\Component\Input\Constraint\StringSize;
 use Linio\Component\Input\Instantiator\InstantiatorInterface;
 use Linio\Component\Input\Instantiator\PropertyInstantiator;
 use PHPUnit\Framework\TestCase;
@@ -118,6 +121,31 @@ class TestNullableRecursiveInputHandler extends InputHandler
             'instantiator' => new PropertyInstantiator(),
             'allow_null' => true,
         ]);
+    }
+}
+
+class TestInputHandlerCascade extends InputHandler
+{
+    public function define(): void
+    {
+        $this->add('name', 'string')
+            ->setRequired(true)
+            ->addConstraint(new StringSize(1, 80));
+
+        $this->add('age', 'int')
+            ->setRequired(true)
+            ->addConstraint(new Range(1, 99));
+
+        $this->add('gender', 'string')
+            ->setRequired(true)
+            ->addConstraint(new Enum(['male', 'female', 'other']));
+
+        $this->add('birthday', 'datetime')
+            ->setRequired(false);
+
+        $this->add('email', 'string')
+            ->setRequired(false)
+            ->addConstraint(new Email());
     }
 }
 
@@ -538,6 +566,21 @@ class InputHandlerTest extends TestCase
         $data = $inputHandler->getData('data');
 
         $this->assertNull($data);
+    }
+
+    public function testInputHandlerOnCascade(): void
+    {
+        $input = [
+            'name' => 'A',
+            'age' => 18,
+            'gender' => 'male',
+            'birthday' => '2000-01-01',
+        ];
+
+        $inputHandler = new TestInputHandlerCascade();
+        $inputHandler->bind($input);
+
+        $this->assertTrue($inputHandler->isValid());
     }
 }
 


### PR DESCRIPTION
The feature to define cascading inputs is implemented to reduce the cost of the code and increase readability. 
Also, recursive handlers can be sent as parameters without losing the option to enter them the traditional way within a variety of options.

Why is this necessary?

When performing unit tests on our repositories that depend on this library, there is a difficulty in accessing the options or configurations defined in an array.
In addition, mutation tests have problems infecting the code and being able to carry out valid tests to cover uncontrolled cases in our codes.

making the definitions by method makes it easier to cover the code and control those random cases.

```php
$this->add('transaction', 'string')
    ->setRequired(false)
    ->addConstraint(new GuidValue())
    ->setTransformer(new UuidTransformer());
```