### PR TITLE
Fix/not required field constraints

### DIFF
--- a/src/Node/BaseNode.php
+++ b/src/Node/BaseNode.php
@@ -275,7 +275,7 @@ class BaseNode
     protected function checkConstraints(string $field, $value): void
     {
         foreach ($this->constraints as $constraint) {
-            if (!$constraint->validate($value)) {
+            if (!$constraint->validate($value) && ($this->isRequired() || !empty($value))) {
                 throw new InvalidConstraintException($constraint->getErrorMessage($field));
             }
         }

--- a/tests/Node/BaseNodeTest.php
+++ b/tests/Node/BaseNodeTest.php
@@ -130,7 +130,7 @@ class BaseNodeTest extends TestCase
         $this->assertEquals(new \DateTime('2014-01-01 00:00:00'), $child->getValue('foobar', '2014-01-01 00:00:00'));
     }
 
-    public function testNotRequiredWithConstraints()
+    public function testNotRequiredWithConstraints() : void
     {
         $typeHandler = $this->prophesize(TypeHandler::class);
         $typeHandler->getType('string')->willReturn(new BaseNode());

--- a/tests/Node/BaseNodeTest.php
+++ b/tests/Node/BaseNodeTest.php
@@ -129,4 +129,19 @@ class BaseNodeTest extends TestCase
         $child = $base->add('foobar', 'string', ['transformer' => new DateTimeTransformer()]);
         $this->assertEquals(new \DateTime('2014-01-01 00:00:00'), $child->getValue('foobar', '2014-01-01 00:00:00'));
     }
+
+    public function testNotRequiredWithConstraints()
+    {
+        $typeHandler = $this->prophesize(TypeHandler::class);
+        $typeHandler->getType('string')->willReturn(new BaseNode());
+
+        $base = new BaseNode();
+        $base->setTypeHandler($typeHandler->reveal());
+        $child = $base->add('foobar', 'string')
+            ->setRequired(false)
+            ->addConstraint(new StringSize(1, 255));
+
+        $this->assertNull($child->getValue('foobar', null));
+        $this->assertEmpty($child->getValue('foobar', ''));
+    }
 }

--- a/tests/Node/BaseNodeTest.php
+++ b/tests/Node/BaseNodeTest.php
@@ -130,7 +130,7 @@ class BaseNodeTest extends TestCase
         $this->assertEquals(new \DateTime('2014-01-01 00:00:00'), $child->getValue('foobar', '2014-01-01 00:00:00'));
     }
 
-    public function testNotRequiredWithConstraints() : void
+    public function testNotRequiredWithConstraints(): void
     {
         $typeHandler = $this->prophesize(TypeHandler::class);
         $typeHandler->getType('string')->willReturn(new BaseNode());


### PR DESCRIPTION
Hey there, I created this PR to address a minor issue in the specific scenario when you have: 
 - an explicitly not required field that is missing in the payload being validated or just has null/empty value;
 - and this field has any constraint (like `StringSize` for instance);

The constraint ends up being validated even when it shouldn't (because the field is not present in the payload).

Let me know what you guys think?

Thanks!

