### PR TITLE
Fix/not required field constraints

### DIFF
--- a/src/Node/BaseNode.php
+++ b/src/Node/BaseNode.php
@@ -283,7 +283,7 @@ class BaseNode
 
     private function checkIfFieldValueIsSpecified($value): bool
     {
-        return ($this->type === 'string' || $this->type === 'array' ? !empty($value) : !is_null($value));
+        return $this->type === 'string' || $this->type === 'array' ? !empty($value) : $value !== null;
     }
 
     private function setHandler(InputHandler $handler, string $type): self

--- a/src/Node/BaseNode.php
+++ b/src/Node/BaseNode.php
@@ -275,10 +275,15 @@ class BaseNode
     protected function checkConstraints(string $field, $value): void
     {
         foreach ($this->constraints as $constraint) {
-            if (!$constraint->validate($value) && ($this->isRequired() || !empty($value))) {
+            if (!$constraint->validate($value) && ($this->isRequired() || $this->checkIfFieldValueIsSpecified($value))) {
                 throw new InvalidConstraintException($constraint->getErrorMessage($field));
             }
         }
+    }
+
+    private function checkIfFieldValueIsSpecified($value): bool
+    {
+        return ($this->type === 'string' || $this->type === 'array' ? !empty($value) : !is_null($value));
     }
 
     private function setHandler(InputHandler $handler, string $type): self

--- a/tests/Node/BaseNodeTest.php
+++ b/tests/Node/BaseNodeTest.php
@@ -159,11 +159,9 @@ class BaseNodeTest extends TestCase
             ->addConstraint(new Range(1, 255))
             ->setType('integer');
 
-
         $this->assertEmpty($child->getValue('foobar', null));
 
         $this->expectException(InvalidConstraintException::class);
         $child->getValue('foobar', 0);
-
     }
 }

--- a/tests/Node/BaseNodeTest.php
+++ b/tests/Node/BaseNodeTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Linio\Component\Input\Node;
 
 use Linio\Component\Input\Constraint\NotNull;
+use Linio\Component\Input\Constraint\Range;
 use Linio\Component\Input\Constraint\StringSize;
 use Linio\Component\Input\Exception\InvalidConstraintException;
 use Linio\Component\Input\Transformer\DateTimeTransformer;
@@ -142,6 +143,27 @@ class BaseNodeTest extends TestCase
             ->addConstraint(new StringSize(1, 255));
 
         $this->assertNull($child->getValue('foobar', null));
-        $this->assertEmpty($child->getValue('foobar', ''));
+    }
+
+    public function testNotRequiredWithContraintsAndIntegerField(): void
+    {
+        $typeHandler = $this->prophesize(TypeHandler::class);
+        $typeHandler->getType('integer')->willReturn(new BaseNode());
+
+        $base = new BaseNode();
+        $base->setTypeHandler($typeHandler->reveal());
+        $base->setTypeAlias('integer');
+        $child = $base->add('foobar', 'integer')
+            ->setTypeAlias('integer')
+            ->setRequired(false)
+            ->addConstraint(new Range(1, 255))
+            ->setType('integer');
+
+
+        $this->assertEmpty($child->getValue('foobar', null));
+
+        $this->expectException(InvalidConstraintException::class);
+        $child->getValue('foobar', 0);
+
     }
 }


### PR DESCRIPTION
I made this PR to solve a minor bug that was introduced in my previous fix PR (#50).

When checking if the field is filled, we were not considering the type of it. For numbers, we should run this check if `is_null` instead of `empty`, otherwise we would run into trouble regarding inconsistent behaviors, like the one in the test I wrote.