### PR TITLE
chore: Update PHP to 8.1 and dependencies

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
       with:
-        php-version: '7.2'
+        php-version: '8.1'
 
     - name: Validate composer.json and composer.lock
       run: composer validate --strict

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ composer.phar
 composer.lock
 phpunit.xml
 cache.properties
-.php_cs.cache
+.php-cs-fixer.cache
 .phpunit.result.cache
 .idea/
+/data/cache/*

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -4,7 +4,7 @@ $finder = PhpCsFixer\Finder::create()
     ->in(__DIR__ . '/src')
     ->in(__DIR__ . '/tests');
 
-return PhpCsFixer\Config::create()
+return (new PhpCsFixer\Config())
     ->setRules([
         '@Symfony' => true,
         '@PHP71Migration:risky' => true,
@@ -15,12 +15,12 @@ return PhpCsFixer\Config::create()
         'concat_space' => ['spacing' => 'one'],
         'declare_strict_types' => true,
         'increment_style' => ['style' => 'post'],
-        'is_null' => ['use_yoda_style' => false],
+        'is_null' => true,
         'list_syntax' => ['syntax' => 'short'],
-        'method_argument_space' => ['ensure_fully_multiline' => true],
+        'method_argument_space' => true,
         'method_chaining_indentation' => true,
         'modernize_types_casting' => true,
-        'no_multiline_whitespace_before_semicolons' => true,
+        'multiline_whitespace_before_semicolons' => false,
         'no_superfluous_elseif' => true,
         'no_superfluous_phpdoc_tags' => true,
         'no_useless_else' => true,

--- a/composer.json
+++ b/composer.json
@@ -5,13 +5,50 @@
     "type": "library",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=7.2",
-        "ramsey/uuid": "^3.8|^4.0",
+        "php": "^8.1",
+        "ramsey/uuid": "^4.5",
         "doctrine/inflector": "^2.0"
     },
     "require-dev": {
-        "phpunit/phpunit": ">=6.0",
-        "friendsofphp/php-cs-fixer": "^2.4"
+        "friendsofphp/php-cs-fixer": "^3.11",
+        "michaelmoussa/php-coverage-checker": "^1.1",
+        "phpunit/phpunit": "^9.5",
+        "phpspec/prophecy": "^1.15",
+        "phpspec/prophecy-phpunit": "^2.0",
+        "phpstan/phpstan": "^0.12"
+    },
+    "scripts": {
+        "lint": [
+            "php-cs-fixer fix --ansi --verbose --show-progress=dots"
+        ],
+        "lint:check": [
+            "@lint --dry-run"
+        ],
+        "test:base": [
+            "php -d pcov.enabled=1 vendor/bin/phpunit --color=always"
+        ],
+        "test": [
+            "@test:base --log-junit build/junit.xml --coverage-xml build/coverage-xml --coverage-clover build/coverage-clover.xml"
+        ],
+        "test:with-html-coverage": [
+            "@test:base --coverage-html build/coverage-html"
+        ],
+        "test:coverage-checker": [
+            "php-coverage-checker build/coverage-clover.xml 92;"
+        ],
+        "test:check": [
+            "if [ -f build/coverage-clover.xml ]; then rm build/coverage-clover.xml; echo '>>> REMOVED OLD CLOVER.XML BUILD FILE!'; fi; # comment trick to allow composer params :D",
+            "@test",
+            "@test:coverage-checker"
+        ],
+        "check": [
+            "@lint:check",
+            "@test:check",
+            "@static-analysis"
+        ],
+        "static-analysis": [
+            "phpstan analyse --ansi --memory-limit=-1"
+        ]
     },
     "autoload": {
         "psr-4": {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,7 @@
+parameters:
+    level: 0 # start increasing the level
+    paths:
+        - src
+        - tests
+    tmpDir: data/cache/phpstan
+    reportUnmatchedIgnoredErrors: false

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
          backupGlobals="false"
          colors="true"
          convertErrorsToExceptions="true"
@@ -9,19 +8,19 @@
          convertWarningsToExceptions="true"
          stopOnFailure="false"
          bootstrap="./vendor/autoload.php">
-    <testsuites>
-        <testsuite name="Linio Framework Test Suite">
-            <directory>./tests</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist addUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./src</directory>
-            <exclude>
-                <file>src/Input/Constraint/ConstraintInterface.php</file>
-                <file>src/Input/Transformer/TransformerInterface.php</file>
-                <file>src/Input/InputTrait.php</file>
-            </exclude>
-        </whitelist>
-    </filter>
+  <coverage includeUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+    <exclude>
+      <file>src/Input/Constraint/ConstraintInterface.php</file>
+      <file>src/Input/Transformer/TransformerInterface.php</file>
+      <file>src/Input/InputTrait.php</file>
+    </exclude>
+  </coverage>
+  <testsuites>
+    <testsuite name="Linio Framework Test Suite">
+      <directory>./tests</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/Constraint/GuidValue.php
+++ b/src/Constraint/GuidValue.php
@@ -6,7 +6,7 @@ namespace Linio\Component\Input\Constraint;
 
 class GuidValue extends Constraint
 {
-    const ERROR_MESSAGE = 'Invalid GUID format';
+    public const ERROR_MESSAGE = 'Invalid GUID format';
 
     public function __construct(string $errorMessage = null)
     {

--- a/src/Constraint/UuidValue.php
+++ b/src/Constraint/UuidValue.php
@@ -6,5 +6,5 @@ namespace Linio\Component\Input\Constraint;
 
 class UuidValue extends GuidValue
 {
-    const ERROR_MESSAGE = 'Invalid UUID format';
+    public const ERROR_MESSAGE = 'Invalid UUID format';
 }

--- a/src/Transformer/UuidTransformer.php
+++ b/src/Transformer/UuidTransformer.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Linio\Component\Input\Transformer;
 
-use Exception;
 use Linio\Component\Input\Exception\TransformationException;
 use Ramsey\Uuid\Uuid;
 
@@ -14,7 +13,7 @@ class UuidTransformer implements TransformerInterface
     {
         try {
             return Uuid::fromString($value);
-        } catch (Exception $exception) {
+        } catch (\Exception $exception) {
             throw new TransformationException($exception->getMessage());
         }
     }

--- a/tests/Constraint/DateRangeTest.php
+++ b/tests/Constraint/DateRangeTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Linio\Component\Input\Constraint;
 
-use PHPUnit\Framework\TestCase;
+use Linio\Component\Input\TestCase;
 
 class DateRangeTest extends TestCase
 {

--- a/tests/Constraint/DateTimeTest.php
+++ b/tests/Constraint/DateTimeTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Linio\Component\Input\Constraint;
 
-use PHPUnit\Framework\TestCase;
+use Linio\Component\Input\TestCase;
 
 class DateTimeTest extends TestCase
 {

--- a/tests/Constraint/EmailTest.php
+++ b/tests/Constraint/EmailTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Linio\Component\Input\Constraint;
 
-use PHPUnit\Framework\TestCase;
+use Linio\Component\Input\TestCase;
 
 class EmailTest extends TestCase
 {

--- a/tests/Constraint/EnumTest.php
+++ b/tests/Constraint/EnumTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Linio\Component\Input\Constraint;
 
-use PHPUnit\Framework\TestCase;
+use Linio\Component\Input\TestCase;
 
 class EnumTest extends TestCase
 {

--- a/tests/Constraint/GuidValueTest.php
+++ b/tests/Constraint/GuidValueTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Linio\Component\Input\Constraint;
 
-use PHPUnit\Framework\TestCase;
+use Linio\Component\Input\TestCase;
 
 class GuidValueTest extends TestCase
 {

--- a/tests/Constraint/NotNullTest.php
+++ b/tests/Constraint/NotNullTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Linio\Component\Input\Constraint;
 
-use PHPUnit\Framework\TestCase;
+use Linio\Component\Input\TestCase;
 
 class NotNullTest extends TestCase
 {

--- a/tests/Constraint/PatternTest.php
+++ b/tests/Constraint/PatternTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Linio\Component\Input\Constraint;
 
-use PHPUnit\Framework\TestCase;
+use Linio\Component\Input\TestCase;
 
 class PatternTest extends TestCase
 {

--- a/tests/Constraint/RangeTest.php
+++ b/tests/Constraint/RangeTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Linio\Component\Input\Constraint;
 
-use PHPUnit\Framework\TestCase;
+use Linio\Component\Input\TestCase;
 
 class RangeTest extends TestCase
 {

--- a/tests/Constraint/StringSizeTest.php
+++ b/tests/Constraint/StringSizeTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Linio\Component\Input\Constraint;
 
-use PHPUnit\Framework\TestCase;
+use Linio\Component\Input\TestCase;
 
 class StringSizeTest extends TestCase
 {

--- a/tests/Constraint/TypeTest.php
+++ b/tests/Constraint/TypeTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Linio\Component\Input\Constraint;
 
-use PHPUnit\Framework\TestCase;
+use Linio\Component\Input\TestCase;
 
 class TypeTest extends TestCase
 {

--- a/tests/Constraint/UrlTest.php
+++ b/tests/Constraint/UrlTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Linio\Component\Input\Constraint;
 
-use PHPUnit\Framework\TestCase;
+use Linio\Component\Input\TestCase;
 
 class UrlTest extends TestCase
 {

--- a/tests/Constraint/UuidValueTest.php
+++ b/tests/Constraint/UuidValueTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Linio\Component\Input\Constraint;
 
-use PHPUnit\Framework\TestCase;
+use Linio\Component\Input\TestCase;
 
 class UuidValueTest extends TestCase
 {

--- a/tests/InputHandlerTest.php
+++ b/tests/InputHandlerTest.php
@@ -10,7 +10,6 @@ use Linio\Component\Input\Constraint\Range;
 use Linio\Component\Input\Constraint\StringSize;
 use Linio\Component\Input\Instantiator\InstantiatorInterface;
 use Linio\Component\Input\Instantiator\PropertyInstantiator;
-use PHPUnit\Framework\TestCase;
 
 class TestUser
 {

--- a/tests/Instantiator/ConstructInstantiatorTest.php
+++ b/tests/Instantiator/ConstructInstantiatorTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Linio\Component\Input\Instantiator;
 
 use Linio\Component\Input\Constraint\Enum;
-use PHPUnit\Framework\TestCase;
+use Linio\Component\Input\TestCase;
 
 class ConstructInstantiatorTest extends TestCase
 {

--- a/tests/Instantiator/PropertyInstantiatorTest.php
+++ b/tests/Instantiator/PropertyInstantiatorTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Linio\Component\Input\Instantiator;
 
+use Linio\Component\Input\TestCase;
 use Linio\Component\Input\TestUser;
-use PHPUnit\Framework\TestCase;
 
 class PropertyInstantiatorTest extends TestCase
 {

--- a/tests/Instantiator/ReflectionInstantiatorTest.php
+++ b/tests/Instantiator/ReflectionInstantiatorTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Linio\Component\Input\Instantiator;
 
+use Linio\Component\Input\TestCase;
 use Linio\Component\Input\TestUser;
-use PHPUnit\Framework\TestCase;
 
 class ReflectionInstantiatorTest extends TestCase
 {

--- a/tests/Instantiator/SetInstantiatorTest.php
+++ b/tests/Instantiator/SetInstantiatorTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Linio\Component\Input\Instantiator;
 
+use Linio\Component\Input\TestCase;
 use Linio\Component\Input\TestUser;
-use PHPUnit\Framework\TestCase;
 
 class SetInstantiatorTest extends TestCase
 {

--- a/tests/Node/BaseNodeTest.php
+++ b/tests/Node/BaseNodeTest.php
@@ -8,9 +8,9 @@ use Linio\Component\Input\Constraint\NotNull;
 use Linio\Component\Input\Constraint\Range;
 use Linio\Component\Input\Constraint\StringSize;
 use Linio\Component\Input\Exception\InvalidConstraintException;
+use Linio\Component\Input\TestCase;
 use Linio\Component\Input\Transformer\DateTimeTransformer;
 use Linio\Component\Input\TypeHandler;
-use PHPUnit\Framework\TestCase;
 
 class BaseNodeTest extends TestCase
 {

--- a/tests/Node/CollectionNodeTest.php
+++ b/tests/Node/CollectionNodeTest.php
@@ -7,8 +7,8 @@ namespace Linio\Component\Input\Node;
 use Linio\Component\Input\Constraint\ConstraintInterface;
 use Linio\Component\Input\Exception\InvalidConstraintException;
 use Linio\Component\Input\Instantiator\InstantiatorInterface;
+use Linio\Component\Input\TestCase;
 use Linio\Component\Input\TypeHandler;
-use PHPUnit\Framework\TestCase;
 
 class CollectionNodeTest extends TestCase
 {

--- a/tests/Node/IntNodeTest.php
+++ b/tests/Node/IntNodeTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Linio\Component\Input\Node;
 
-use PHPUnit\Framework\TestCase;
+use Linio\Component\Input\TestCase;
 
 class IntNodeTest extends TestCase
 {

--- a/tests/Node/ObjectNodeTest.php
+++ b/tests/Node/ObjectNodeTest.php
@@ -7,8 +7,8 @@ namespace Linio\Component\Input\Node;
 use Linio\Component\Input\Constraint\ConstraintInterface;
 use Linio\Component\Input\Exception\InvalidConstraintException;
 use Linio\Component\Input\Instantiator\InstantiatorInterface;
+use Linio\Component\Input\TestCase;
 use Linio\Component\Input\TypeHandler;
-use PHPUnit\Framework\TestCase;
 
 class ObjectNodeTest extends TestCase
 {

--- a/tests/Node/ScalarCollectionNodeTest.php
+++ b/tests/Node/ScalarCollectionNodeTest.php
@@ -6,8 +6,8 @@ namespace Linio\Component\Input\Node;
 
 use Linio\Component\Input\Constraint\ConstraintInterface;
 use Linio\Component\Input\Exception\InvalidConstraintException;
+use Linio\Component\Input\TestCase;
 use Linio\Component\Input\TypeHandler;
-use PHPUnit\Framework\TestCase;
 
 class ScalarCollectionNodeTest extends TestCase
 {

--- a/tests/SchemaBuilderTest.php
+++ b/tests/SchemaBuilderTest.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Linio\Component\Input;
 
-use PHPUnit\Framework\TestCase;
-
 class SchemaTestInputHandler extends InputHandler
 {
     public function define(): void

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Linio\Component\Input;
+
+use PHPUnit\Framework\TestCase as PHPUnitTestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+
+class TestCase extends PHPUnitTestCase
+{
+    use ProphecyTrait;
+}

--- a/tests/Transformer/DateTimeTransformerTest.php
+++ b/tests/Transformer/DateTimeTransformerTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Linio\Component\Input\Transformer;
 
-use PHPUnit\Framework\TestCase;
+use Linio\Component\Input\TestCase;
 
 class DateTimeTransformerTest extends TestCase
 {

--- a/tests/Transformer/UuidTransformerTest.php
+++ b/tests/Transformer/UuidTransformerTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Linio\Component\Input\Transformer;
 
 use Linio\Component\Input\Exception\TransformationException;
-use PHPUnit\Framework\TestCase;
+use Linio\Component\Input\TestCase;
 use Ramsey\Uuid\Uuid;
 use Ramsey\Uuid\UuidInterface;
 

--- a/tests/TypeHandlerTest.php
+++ b/tests/TypeHandlerTest.php
@@ -9,7 +9,6 @@ use Linio\Component\Input\Node\CollectionNode;
 use Linio\Component\Input\Node\DateTimeNode;
 use Linio\Component\Input\Node\ObjectNode;
 use Linio\Component\Input\Node\ScalarCollectionNode;
-use PHPUnit\Framework\TestCase;
 
 class TypeHandlerTest extends TestCase
 {


### PR DESCRIPTION
### Changes
1. Upgrade PHP to version 8.1.
2. Update dependencies to version with PHP 8.1 support.
3. Minor changes made by php-cs-fixer.
4. Add custom TestCase class for future customizations.